### PR TITLE
test: Verify server exit code during graceful process shutdown.

### DIFF
--- a/test/pylib/scylla_cluster.py
+++ b/test/pylib/scylla_cluster.py
@@ -516,6 +516,8 @@ class ScyllaServer:
             wait_task = self.cmd.wait()
             try:
                 await asyncio.wait_for(wait_task, timeout=STOP_TIMEOUT_SECONDS)
+                if self.cmd.returncode != 0:
+                    raise RuntimeError(f"Server {self} exited with non-zero exit code: {self.cmd.returncode}")
             except asyncio.TimeoutError:
                 self.cmd.kill()
                 await self.cmd.wait()


### PR DESCRIPTION
| `TimeUnit` value |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
| :----------------: | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| DAYS             | ✅                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
| HOURS            | ✅                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
| MINUTES          | ✅                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
| SECONDS          | ✅                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
| MILLISECONDS     | already supported                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
| MICROSECONDS     | already supported                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
| NANOSECONDS      | do not support; the minimum time resolution for the [api::timestamp_type](https://github.com/scylladb/scylladb/blob/master/timestamp.hh#L19) is [microseconds](https://github.com/scylladb/scylladb/blob/master/timestamp.hh#L31); we'd need to cast nanoseconds to microseconds or change the minimum time resolution.. see [time_window_compaction_strategy.hh#L92-L93](https://github.com/scylladb/scylladb/blob/master/compaction/time_window_compaction_strategy.hh#L92-L93) |